### PR TITLE
Adding remotes to release branches and auto-push for new release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,3 @@ plugins {
     id("com.akuleshov7.buildutils.publishing-configuration")
     id("com.akuleshov7.vercraft.plugin-gradle") version("0.0.1")
 }
-

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Branch.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Branch.kt
@@ -10,11 +10,13 @@ public class Branch(git: Git, public val ref: Ref) {
     /**
      * Counts the number of commits (from the end) which were made in branch after the [[startCommit]]. For example:
      * 1 -> 2 -> 3 -> 4 -> latest
+     * + -> + -> v0 -> v1 -> v2
      * commitNumberAfterThis(3) == 2
      */
     public fun numberOfCommitsAfter(startCommit: RevCommit): Int {
         var count = 0
-        gitLog.reversed().forEach { commitInBranch ->
+        // gitLog is always reverted from the last commit to the first one
+        gitLog.forEach { commitInBranch ->
             if (commitInBranch.id.name != startCommit.id.name) {
                 ++count
             } else {
@@ -36,9 +38,14 @@ public class Branch(git: Git, public val ref: Ref) {
      *  The base commit is 2.
      */
     public fun findBaseCommitIn(sourceBase: Branch): RevCommit? {
-        this.gitLog.reversed().forEach { commitInSub ->
-            // lastOrNull is optimized to make search from the end
-            val thisCommitInMainBranch = sourceBase.gitLog.lastOrNull { commitInSub.id.name == it.id.name }
+        // (!) gitLog is always in a reversed order (from last to first commit):
+        // 4 3 2 1
+        // 6 5 2
+        // ^ 6 not found
+        //   ^ 5 not found
+        //     ^ 2 - is a common commit
+        this.gitLog.forEach { commitInSub ->
+            val thisCommitInMainBranch = sourceBase.gitLog.firstOrNull { commitInSub.id.name == it.id.name }
             if (thisCommitInMainBranch != null) {
                 return thisCommitInMainBranch
             }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Branch.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Branch.kt
@@ -12,8 +12,8 @@ public class Branch(git: Git, public val ref: Ref) {
      * 1 -> 2 -> 3 -> 4 -> latest
      * commitNumberAfterThis(3) == 2
      */
-    public fun numberOfCommitsAfter(startCommit: RevCommit): Long {
-        var count = 0L
+    public fun numberOfCommitsAfter(startCommit: RevCommit): Int {
+        var count = 0
         gitLog.reversed().forEach { commitInBranch ->
             if (commitInBranch.id.name != startCommit.id.name) {
                 ++count

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/LocalCredentialsProvider.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/LocalCredentialsProvider.kt
@@ -1,0 +1,16 @@
+package com.akuleshov7.vercraft.core
+
+import org.eclipse.jgit.transport.CredentialItem
+import org.eclipse.jgit.transport.CredentialsProvider
+import org.eclipse.jgit.transport.URIish
+
+public object LocalCredentialsProvider : CredentialsProvider() {
+    override fun isInteractive(): Boolean = false
+
+    override fun supports(vararg items: CredentialItem?): Boolean = true
+
+    override fun get(uri: URIish?, vararg items: CredentialItem?): Boolean {
+        // Let JGit use system credentials (e.g., SSH agent or ~/.git-credentials)
+        return true
+    }
+}

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
@@ -16,7 +16,9 @@ internal const val RELEASE_PREFIX = "release"
  *
  * TODO: add configuration for remotes other than 'origin'
  */
-internal fun String.shortName() = Repository.shortenRefName(this).substringAfterLast(Constants.DEFAULT_REMOTE_NAME + "/")
+internal fun String.shortName() =
+    Repository.shortenRefName(this).substringAfterLast(Constants.DEFAULT_REMOTE_NAME + "/")
+
 internal fun String.removeReleasePrefix() = this.substringAfterLast("$RELEASE_PREFIX/")
 internal fun String.hasReleasePrefix() = this.startsWith("$RELEASE_PREFIX/")
 
@@ -39,7 +41,7 @@ public class Releases public constructor(private val git: Git) {
         try {
             git.fetch().call()
         } catch (e: TransportException) {
-            logger.warn("(!) Not able to fetch remote repository <${e.message}>, will proceed with local snapshot")
+            logger.warn("(!) Not able to fetch remote repository <${e.message}>, will proceed with local snapshot.")
         }
     }
 
@@ -58,6 +60,7 @@ public class Releases public constructor(private val git: Git) {
     public fun getLatestReleaseBranch(): ReleaseBranch? =
         releaseBranches.maxByOrNull { it.version }
 
+    // TODO: Not to create a release if we are now on main and on this commit there is already a release branch made
     public fun createNewRelease(releaseType: SemVerReleaseType): String {
         val newVersion = getLatestReleaseBranch()
             ?.version
@@ -67,7 +70,7 @@ public class Releases public constructor(private val git: Git) {
         if (currentCheckoutBranch != mainBranch) {
             throw IllegalStateException(
                 "(!) Branch which is currently checked out is [${currentCheckoutBranch.ref.name}], " +
-                        "but ${releaseType.name} release should be done from [${mainBranch.ref.name}] branch. " +
+                        "but ${releaseType.name} release should always be done from [${mainBranch.ref.name}] branch. " +
                         "Because during the release VerCraft will create a new branch and tag."
             )
         } else {
@@ -79,7 +82,9 @@ public class Releases public constructor(private val git: Git) {
                 // FIXME: need to switch to latest release branch and latest commit and set release tag there
             } else {
                 createBranch(newVersion)
+                pushBranch(newVersion)
                 createTag(newVersion)
+                pushTag(newVersion)
             }
         }
         return "$newVersion"
@@ -91,21 +96,22 @@ public class Releases public constructor(private val git: Git) {
                 "(!) The branch with the version [$version] which was selected for " +
                         "the new release already exists. No branches will be created, please change the version."
             )
-
         } else {
             createBranch(version)
+            pushBranch(version)
             createTag(version)
+            pushTag(version)
         }
         return version.toString()
     }
 
     private fun createTag(newVersion: SemVer) {
         git.tag()
-            .setName(newVersion.toString())
+            .setName("v${newVersion}")
             .setMessage("Release $newVersion")
             .call()
 
-        logger.warn("+ Created a tag [Release $newVersion]")
+        logger.warn("+ Created a tag v$newVersion [Release $newVersion]")
     }
 
     private fun createBranch(newVersion: SemVer) {
@@ -117,6 +123,32 @@ public class Releases public constructor(private val git: Git) {
         logger.warn("+ Created a branch [release/$newVersion]")
     }
 
+    private fun pushBranch(newVersion: SemVer) {
+        try {
+            git.push()
+                .setCredentialsProvider(LocalCredentialsProvider)
+                .add("release/$newVersion")
+                .call()
+
+            logger.warn("+ Pushed a branch [release/$newVersion]")
+        } catch (e: TransportException) {
+            logger.warn("(!) Not able to push branch to remote repository <${e.message}>, please do it manually.")
+        }
+    }
+
+    private fun pushTag(newVersion: SemVer) {
+        try {
+            git.push()
+                .setCredentialsProvider(LocalCredentialsProvider)
+                .add("refs/tags/v$newVersion")
+                .call()
+
+            logger.warn("+ Pushed a tag v$newVersion [Release $newVersion]")
+        } catch (e: TransportException) {
+            logger.warn("(!) Not able to push tag to remote repository <${e.message}>, please do it manually.")
+        }
+    }
+
     /**
      * We have two sources for release branches: they can be created locally or can be taken from `remotes/origin`
      */
@@ -126,16 +158,20 @@ public class Releases public constructor(private val git: Git) {
         val releaseBranchesFromRemote = getAndFilterReleaseBranches(git.branchList().setListMode(REMOTE))
         val localReleaseBranches = getAndFilterReleaseBranches(git.branchList().setListMode(null))
 
-        // we will union LOCAL branches with REMOTE, with a priority to LOCAL
+        // we will make a union of LOCAL branches and REMOTE, with a priority to LOCAL
         val allReleaseBranches = (localReleaseBranches + releaseBranchesFromRemote)
             .groupBy { it.branch.ref.name.shortName() }
 
         allReleaseBranches.keys.forEach {
-            if(allReleaseBranches[it]!!.size > 1) {
-                if(allReleaseBranches[it]!![0].branch.gitLog != allReleaseBranches[it]!![1].branch.gitLog) {
+            val value = allReleaseBranches[it]
+            if (value!!.size > 1) {
+                if (value[0].branch.gitLog != value[1].branch.gitLog) {
                     // TODO: error when release branch is checked-out (and calculating version for it) and differs from remote
-                    logger.warn("jFYI: Remote branch $it differs from the local branch $it. " +
-                            "Do you have any unpublished changes in your local branch?")
+                    logger.warn(
+                        "(!) jFYI: Remote and local branches '$it' differ. " +
+                                "Do you have any unpublished changes in your local branch? Will use " +
+                                "local branch to calculate versions."
+                    )
                 }
             }
         }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Runner.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Runner.kt
@@ -10,7 +10,7 @@ public fun getVersion(gitPath: File): String {
     Git.open(gitPath).use { git ->
         val releases = Releases(git)
         val resultedVer = releases.version.calc()
-        logger.warn("VERsion CRAFTED: $resultedVer")
+        logger.warn(">> VERsion CRAFTED: $resultedVer <<")
         return resultedVer.toString()
     }
 }
@@ -18,7 +18,7 @@ public fun getVersion(gitPath: File): String {
 public fun createRelease(gitPath: File, semVerReleaseType: SemVerReleaseType): String {
     Git.open(gitPath).use { git ->
         val version = Releases(git).createNewRelease(semVerReleaseType)
-        logger.warn("Successfully \"VerCrafted\" the release [$version]")
+        logger.warn(">> \"VerCrafted\" the release [$version] <<")
         return version
     }
 }
@@ -32,5 +32,5 @@ public fun createRelease(gitPath: File, version: SemVer) {
 
 
 public fun main() {
-    getVersion(File("../data-platform"))
+    createRelease(File("../data-platform"), SemVerReleaseType.MINOR)
 }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Runner.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Runner.kt
@@ -1,26 +1,36 @@
 package com.akuleshov7.vercraft.core
 
+import org.apache.logging.log4j.LogManager
 import org.eclipse.jgit.api.Git
 import java.io.File
 
+private val logger = LogManager.getLogger()
 
 public fun getVersion(gitPath: File): String {
     Git.open(gitPath).use { git ->
         val releases = Releases(git)
         val resultedVer = releases.version.calc()
-        // FixMe: logging
+        logger.warn("VERsion CRAFTED: $resultedVer")
         return resultedVer.toString()
     }
 }
 
 public fun createRelease(gitPath: File, semVerReleaseType: SemVerReleaseType): String {
     Git.open(gitPath).use { git ->
-        return Releases(git).createNewRelease(semVerReleaseType)
+        val version = Releases(git).createNewRelease(semVerReleaseType)
+        logger.warn("Successfully \"VerCrafted\" the release [$version]")
+        return version
     }
 }
 
+// TODO: support explicit version creation in Gradle Plugin
 public fun createRelease(gitPath: File, version: SemVer) {
     Git.open(gitPath).use { git ->
         Releases(git).createNewRelease(version)
     }
+}
+
+
+public fun main() {
+    getVersion(File("../data-platform"))
 }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/SemVer.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/SemVer.kt
@@ -21,13 +21,13 @@ public enum class SemVerReleaseType {
  * The only reason why it is not a data class, because I wanted a parsing logic in secondary constructor.
  */
 public class SemVer : Comparable<SemVer> {
-    public val major: Long
-    public val minor: Long
-    public val patch: Long
-    public var postfix: String = ""
+    public val major: Int
+    public val minor: Int
+    public val patch: Int
+    private var postfix: String = ""
 
     public constructor(ver: String) {
-        val parts = ver.split(".").map { it.toLong() }
+        val parts = ver.removeReleasePrefix().split(".").map { it.toInt() }
         require(parts.size == 3) {
             throw IllegalArgumentException("SemVer version [$this] must be in the following format: 'major.minor.patch'")
         }
@@ -36,7 +36,7 @@ public class SemVer : Comparable<SemVer> {
         patch = parts[2]
     }
 
-    public constructor(major: Long, minor: Long, patch: Long) {
+    public constructor(major: Int, minor: Int, patch: Int) {
         this.major = major
         this.minor = minor
         this.patch = patch
@@ -82,7 +82,7 @@ public class SemVer : Comparable<SemVer> {
         PATCH -> SemVer(major, minor, patch + 1)
     }
 
-    public fun incrementPatchVersion(increment: Long): SemVer = SemVer(major, minor, patch + increment)
+    public fun incrementPatchVersion(increment: Int): SemVer = SemVer(major, minor, patch + increment)
 
     public fun setPostFix(postfix: String): SemVer {
         this.postfix = postfix
@@ -98,14 +98,6 @@ public class SemVer : Comparable<SemVer> {
 }
 
 public fun String.isValidSemVerFormat(): Boolean {
-    try {
-        SemVer(this.removePrefix())
-    } catch (ex: Exception) {
-        when (ex) {
-            // only those exceptions are known to be thrown in case of invalid parsing in `parseSemVer`
-            is NumberFormatException, is IllegalArgumentException -> return false
-            else -> throw ex
-        }
-    }
-    return true
+    val semVerRegex = Regex("""^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$""")
+    return semVerRegex.matches(this)
 }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/SemVer.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/SemVer.kt
@@ -2,6 +2,8 @@ package com.akuleshov7.vercraft.core
 
 import com.akuleshov7.vercraft.core.SemVerReleaseType.*
 
+internal const val NO_MAJOR = -1
+internal const val NO_MINOR = -1
 
 public enum class SemVerReleaseType {
     MAJOR,
@@ -24,6 +26,7 @@ public class SemVer : Comparable<SemVer> {
     public val major: Int
     public val minor: Int
     public val patch: Int
+    public var prefix: String = ""
     private var postfix: String = ""
 
     public constructor(ver: String) {
@@ -40,7 +43,6 @@ public class SemVer : Comparable<SemVer> {
         this.major = major
         this.minor = minor
         this.patch = patch
-
     }
 
     public override operator fun compareTo(other: SemVer): Int {
@@ -73,7 +75,12 @@ public class SemVer : Comparable<SemVer> {
     }
 
     override fun toString(): String {
-        return "$major.$minor.$patch${if (postfix != "") "-$postfix" else ""}"
+        val major = if (this.major == NO_MAJOR) "" else "${this.major}."
+        val minor = if (this.minor == NO_MINOR) "" else "${this.minor}."
+
+        return (if (prefix != "") "$prefix-" else "") +
+                "$major$minor${this.patch}" +
+                (if (postfix != "") "-$postfix" else "")
     }
 
     public fun nextVersion(nextVersion: SemVerReleaseType): SemVer = when (nextVersion) {
@@ -86,6 +93,11 @@ public class SemVer : Comparable<SemVer> {
 
     public fun setPostFix(postfix: String): SemVer {
         this.postfix = postfix
+        return this
+    }
+
+    public fun setPrefix(prefix: String): SemVer {
+        this.prefix = prefix
         return this
     }
 

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
@@ -20,7 +20,7 @@ public class VersionCalculator(
 
     public fun calc(): SemVer =
         when {
-            currentCheckoutBranch.ref.name == "$REFS_HEADS/$MAIN_BRANCH_NAME" -> calcVersionInMain()
+            currentCheckoutBranch.ref.name.shortName() == MAIN_BRANCH_NAME -> calcVersionInMain()
             releases.isReleaseBranch(currentCheckoutBranch) -> calcVersionInRelease()
             else -> calcVersionInBranch()
         }
@@ -54,7 +54,7 @@ public class VersionCalculator(
                 latestRelease.version
                     .nextVersion(SemVerReleaseType.MINOR)
                     .incrementPatchVersion(distance)
-                    .setPostFix("rc-$shortedHashCode")
+                    .setPostFix("rc+$shortedHashCode")
             }
             ?: run { SemVer(0, 0, distance) }
     }
@@ -125,11 +125,11 @@ public class VersionCalculator(
             dateFormat.timeZone = TimeZone.getDefault()
             val formattedDate = dateFormat.format(Date(commit.commitTime * 1000L))
 
-            return SemVer(0, 0, distance + 1).setPostFix("$branch-$formattedDate")
+            return SemVer(0, 0, distance + 1).setPostFix("$branch+$formattedDate")
         }
     }
 
-    private fun distanceFromMainBranch(): Long {
+    private fun distanceFromMainBranch(): Int {
         val baseCommit = currentCheckoutBranch.findBaseCommitIn(releases.mainBranch)
             ?: throw IllegalStateException(
                 "Can't find common ancestor commits between $MAIN_BRANCH_NAME " +

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
@@ -32,13 +32,14 @@ public class VersionCalculator(
      *
      * aaa -> bbb (release/0.1.0) -> xxx -> yyy (?)
      *
-     * The version for commit yyy is derived by adding the number of commits between
-     * commits bbb and yyy (in this case, 2 commits) to the incremented MINOR version of the
-     * last release version (0.1.0). Therefore, the resulting version for (yyy) will be 0.2.1.
+     * The version for commit yyy is derived by:
+     * 1) incremented MINOR version of the last release version (0.1.0)
+     * 2) incrementing PATCH version by the number of commits between commits bbb and yyy (in this case, 2 commits).
+     * Therefore, the resulting version for (yyy) will be 0.2.1.
      *
-     * (!) Additionally, the version will be appended with a postfix consisting of
-     * the first 5 characters of the commit hash and "-rc". So the result will be as following:
-     * aaa -> bbb (release/0.1.0) -> 0.2.0-hash-rc -> 0.2.1-hash-rc (?)
+     * (!) Additionally, to avoid the confusion with releases, the version will be appended with a postfix consisting of
+     * "-main" and the first 5 characters of the commit hash. So the result will be as following:
+     * aaa -> bbb (release/0.1.0) -> 0.2.0-main+hash -> 0.2.1-main+hash (?)
      */
     private fun calcVersionInMain(): SemVer {
         val latestRelease = releases.getLatestReleaseBranch()
@@ -54,7 +55,7 @@ public class VersionCalculator(
                 latestRelease.version
                     .nextVersion(SemVerReleaseType.MINOR)
                     .incrementPatchVersion(distance)
-                    .setPostFix("rc+$shortedHashCode")
+                    .setPostFix("$MAIN_BRANCH_NAME+$shortedHashCode")
             }
             ?: run { SemVer(0, 0, distance) }
     }
@@ -102,12 +103,12 @@ public class VersionCalculator(
      * (where the branch diverged from the main branch) and the current commit. This distance is used as the PATCH version,
      * while the MAJOR and MINOR versions are set to 0 (resulting in a version format of 0.0.x).
      *
-     * (!) Additionally, the version will include a postfix composed of:
+     * (!) Additionally, the version will include:
      * - The last segment of the branch name (substring after the final "/").
      * - The current date in "yyyy-MM-dd" format.
      *
      * For example, if the branch is "feature/blabla" and the commit distance is 1,
-     * the version will be: "0.0.1-blabla-2024-12-24".
+     * the version will be: "2024-12-24-blabla-1". With such version the clean-up of useless branch builds will be easier.
      */
     private fun calcVersionInBranch(): SemVer {
         // replace all special symbols except letters and digits from branch name and limit it to 10 symbols
@@ -125,7 +126,7 @@ public class VersionCalculator(
             dateFormat.timeZone = TimeZone.getDefault()
             val formattedDate = dateFormat.format(Date(commit.commitTime * 1000L))
 
-            return SemVer(0, 0, distance + 1).setPostFix("$branch+$formattedDate")
+            return SemVer(NO_MAJOR, NO_MINOR, distance + 1).setPrefix("$formattedDate-$branch")
         }
     }
 

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
@@ -54,7 +54,7 @@ public class VersionCalculator(
                 latestRelease.version
                     .nextVersion(SemVerReleaseType.MINOR)
                     .incrementPatchVersion(distance)
-                    .setPostFix("$shortedHashCode-rc")
+                    .setPostFix("rc-$shortedHashCode")
             }
             ?: run { SemVer(0, 0, distance) }
     }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/utils/Exceptions.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/utils/Exceptions.kt
@@ -1,0 +1,3 @@
+package com.akuleshov7.vercraft.core.utils
+
+public class ConnectionProblemException(host: String?): Exception("Git cannot connect to the remote repository: <$host>")

--- a/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/GitVersionTask.kt
+++ b/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/GitVersionTask.kt
@@ -22,6 +22,5 @@ abstract class GitVersionTask : DefaultTask() {
         project.allprojects.forEach {
             it.version = version
         }
-        logger.warn("VerCrafted: $version")
     }
 }

--- a/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/MakeReleaseTask.kt
+++ b/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/MakeReleaseTask.kt
@@ -16,7 +16,6 @@ abstract class MakeReleaseTask : DefaultTask() {
 
     @TaskAction
     fun createRelease() {
-        val version = com.akuleshov7.vercraft.core.createRelease(project.projectDir, releaseType.getOrElse(SemVerReleaseType.MINOR))
-        logger.warn("Successfully \"VerCrafted\" the release [$version]")
+        com.akuleshov7.vercraft.core.createRelease(project.projectDir, releaseType.getOrElse(SemVerReleaseType.MINOR))
     }
 }


### PR DESCRIPTION
### What's done:
- Remotes were not added previously to the list of release branches, now they are used together with local release branches (with a priority to local branches);
- Added the logic for automated fetch and push tags and branches to remote during the creation of release;
- Fixing bug with version calculation on release branch (did not expect that gitLog will be reversed);
- Minor enhancements;