### PR TITLE
Hotfix for VerCraft CI usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,3 @@ plugins {
     id("com.akuleshov7.buildutils.publishing-configuration")
     // id("com.akuleshov7.vercraft.plugin-gradle") version("0.0.2")
 }
-
-println("=== ${System.getenv("GITHUB_HEAD_REF")}")
-println("=== ${System.getenv("GITHUB_REF_NAME")}")
-println("=== ${System.getenv("GITHUB_REF")}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
     kotlin("jvm") version ("2.1.0")
     java
     id("com.akuleshov7.buildutils.publishing-configuration")
-    // id("com.akuleshov7.vercraft.plugin-gradle") version("0.0.2")
+    id("com.akuleshov7.vercraft.plugin-gradle") version("0.0.2")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,9 @@ plugins {
     kotlin("jvm") version ("2.1.0")
     java
     id("com.akuleshov7.buildutils.publishing-configuration")
-    id("com.akuleshov7.vercraft.plugin-gradle") version("0.0.2")
+    // id("com.akuleshov7.vercraft.plugin-gradle") version("0.0.2")
 }
+
+println("=== ${System.getenv("GITHUB_HEAD_REF")}")
+println("=== ${System.getenv("GITHUB_REF_NAME")}")
+println("=== ${System.getenv("GITHUB_REF")}")

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Branch.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Branch.kt
@@ -4,6 +4,11 @@ import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.revwalk.RevCommit
 
+public const val GITLAB_BRANCH_REF: String = "CI_COMMIT_REF_NAME"
+public const val GITHUB_BRANCH_REF: String = "GITHUB_REF_NAME"
+public const val BITBUCKET_BRANCH_REF: String = "BITBUCKET_BRANCH"
+public const val VERCRAFT_BRANCH_REF: String = "VERCRAFT_BRANCH"
+
 public class Branch(git: Git, public val ref: Ref) {
     public val gitLog: List<RevCommit> = git.log().add(ref.objectId).call().toList()
 

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Branch.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Branch.kt
@@ -5,7 +5,7 @@ import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.revwalk.RevCommit
 
 public const val GITLAB_BRANCH_REF: String = "CI_COMMIT_REF_NAME"
-public const val GITHUB_BRANCH_REF: String = "GITHUB_REF_NAME"
+public const val GITHUB_HEAD_REF: String = "GITHUB_HEAD_REF"
 public const val BITBUCKET_BRANCH_REF: String = "BITBUCKET_BRANCH"
 public const val VERCRAFT_BRANCH_REF: String = "VERCRAFT_BRANCH"
 

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
@@ -52,7 +52,17 @@ public class Releases public constructor(private val git: Git) {
 
     public val releaseBranches: MutableSet<ReleaseBranch> = findReleaseBranches()
 
-    private val currentCheckoutBranch = Branch(git, repo.findRef(repo.branch))
+    private val currentCheckoutBranch = repo.branch
+        ?.let { Branch(git, repo.findRef(it)) }
+        ?: run {
+            logger.warn(
+                "$ERROR_PREFIX your current HEAD is detached (no branch is checked out). " +
+                        "Usually this happens on CI platforms, which check out particular commit. " +
+                        "Please pass the branch which you are trying to process to VerCraftю"
+            )
+
+            throw NullPointerException("Current checked out branch is null (looks like your current HEAD is detached)")
+        }
 
     public val version: VersionCalculator = VersionCalculator(git, this, currentCheckoutBranch)
 

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
@@ -59,17 +59,17 @@ public class Releases public constructor(private val git: Git) {
                 "$ERROR_PREFIX your current HEAD is detached (no branch is checked out). " +
                         "Usually this happens on CI platforms, which check out particular commit. " +
                         "Trying to resolve branch name using known CI ENV variables: " +
-                        "$GITLAB_BRANCH_REF, $GITHUB_BRANCH_REF, $BITBUCKET_BRANCH_REF."
+                        "$GITLAB_BRANCH_REF, $GITHUB_HEAD_REF, $BITBUCKET_BRANCH_REF."
             )
 
             val branchName = System.getenv(GITLAB_BRANCH_REF)
-                ?: System.getenv(GITHUB_BRANCH_REF)
+                ?: System.getenv(GITHUB_HEAD_REF)
                 ?: System.getenv(BITBUCKET_BRANCH_REF)
                 ?: System.getenv(VERCRAFT_BRANCH_REF)
                 ?: run {
                     logger.warn(
                         "$ERROR_PREFIX following variables are not defined in current env" +
-                                "$GITLAB_BRANCH_REF, $GITHUB_BRANCH_REF, $BITBUCKET_BRANCH_REF" +
+                                "$GITLAB_BRANCH_REF, $GITHUB_HEAD_REF, $BITBUCKET_BRANCH_REF" +
                                 "Please pass the branch name which you are trying to process now explicitly " +
                                 "to VerCraft by setting ENV variable \$VERCRAFT_BRANCH_REF. "
                     )

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
@@ -127,7 +127,9 @@ public class VersionCalculator(
             dateFormat.timeZone = TimeZone.getDefault()
             val formattedDate = dateFormat.format(Date(commit.commitTime * 1000L))
 
-            return SemVer(NO_MAJOR, NO_MINOR, distance + 1).setPrefix("$formattedDate-$branch")
+            return SemVer(NO_MAJOR, NO_MINOR, distance + 1)
+                .setPrefix("$formattedDate-$branch")
+                .setPostFix(commit.name.substring(0, 5))
         }
     }
 


### PR DESCRIPTION
### What's done:
- All CI platforms do not checkout particular branch, but provide a variable, which contains the name of a particular branch;
- So VerCraft tried to get the checked-out branch, but was not able to do it;
- Now VerCraft uses this variable and also has `VERCRAFT_BRANCH_REF` for the branch name to be explicit set;