### PR TITLE
Support for an explicit version set-up

### DIFF
--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Runner.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Runner.kt
@@ -18,14 +18,16 @@ public fun getVersion(gitPath: File, config: Config): String {
 public fun createRelease(gitPath: File, semVerReleaseType: SemVerReleaseType, config: Config): String {
     Git.open(gitPath).use { git ->
         val version = Releases(git, config).createNewRelease(semVerReleaseType)
-        logger.warn(">> \"VerCrafted\" new release [$version] <<")
+        logger.warn(">> VerCrafted new release [$version]")
         return version
     }
 }
 
-// TODO: support explicit version creation in Gradle Plugin
-public fun createRelease(gitPath: File, version: SemVer, config: Config) {
+public fun createRelease(gitPath: File, version: SemVer, config: Config): String {
     Git.open(gitPath).use { git ->
         Releases(git, config).createNewRelease(version)
+        logger.warn(">> VerCrafted new release [$version]")
     }
+
+    return version.toString()
 }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/SemVer.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/SemVer.kt
@@ -24,7 +24,7 @@ public enum class SemVerReleaseType {
                         "$ERROR_PREFIX value [$value] is not allowed as type of SemVer release. " +
                                 "Eligible values are: MAJOR, MINOR, PATCH"
                     )
-                    throw IllegalArgumentException("")
+                    throw IllegalArgumentException("Value [$value] is not allowed as type of SemVer release")
                 }
     }
 }

--- a/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/MakeReleaseTask.kt
+++ b/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/MakeReleaseTask.kt
@@ -2,6 +2,7 @@ package com.akuleshov7.vercraft
 
 import com.akuleshov7.vercraft.core.Config
 import com.akuleshov7.vercraft.core.DefaultConfig
+import com.akuleshov7.vercraft.core.SemVer
 import com.akuleshov7.vercraft.core.SemVerReleaseType
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -18,16 +19,28 @@ abstract class MakeReleaseTask : GitUtilsTask() {
     abstract val releaseType: Property<SemVerReleaseType>
 
     @get:Input
+    abstract val semVer: Property<SemVer>
+
+    @get:Input
     abstract val config: Property<Config>
 
     @TaskAction
-    // TODO: unify common logic for tag and branch
     fun createRelease() {
-        val version = com.akuleshov7.vercraft.core.createRelease(
-            project.projectDir,
-            releaseType.getOrElse(SemVerReleaseType.MINOR),
-            DefaultConfig
-        )
+        val semVerVal = semVer.orNull
+
+        val version = if (semVerVal != null) {
+            com.akuleshov7.vercraft.core.createRelease(
+                project.projectDir,
+                semVerVal,
+                DefaultConfig
+            )
+        } else {
+            com.akuleshov7.vercraft.core.createRelease(
+                project.projectDir,
+                releaseType.getOrElse(SemVerReleaseType.MINOR),
+                DefaultConfig
+            )
+        }
 
         // Push release branch
         gitPushBranch(config.get().remote, "release/$version")

--- a/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/VercraftExtension.kt
+++ b/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/VercraftExtension.kt
@@ -1,20 +1,26 @@
 package com.akuleshov7.vercraft
 
 import com.akuleshov7.vercraft.core.Config
+import com.akuleshov7.vercraft.core.SemVer
 import com.akuleshov7.vercraft.core.SemVerReleaseType
 import com.akuleshov7.vercraft.core.utils.ERROR_PREFIX
 import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import com.akuleshov7.vercraft.core.isValidSemVerFormat
 
-const val ERROR_RELEASE_TYPE_PARSING = "$ERROR_PREFIX Invalid value for `releaseType` property, " +
-        "please check the value in `-PreleaseType`. " +
+const val ERROR_RELEASE_TYPE_PARSING = "$ERROR_PREFIX Invalid value for `$RELEASE_TYPE` property, " +
+        "please check the value in `-P$RELEASE_TYPE`. " +
         "It can only be MAJOR, MINOR or PATCH"
+
+const val ERROR_SEM_VER_PARSING = "$ERROR_PREFIX Invalid version is passed to `$SEM_VER` property, " +
+        "please check the value in `-P$SEM_VER`."
 
 open class VercraftExtension(objectFactory: ObjectFactory) {
     val logger = Logging.getLogger(VercraftExtension::class.java)
     var releaseType: Property<SemVerReleaseType> = objectFactory.property(SemVerReleaseType::class.java)
     var config: Property<Config> = objectFactory.property(Config::class.java)
+    var semVer: Property<SemVer> = objectFactory.property(SemVer::class.java)
 
     fun setReleaseTypeFromProps(prop: Any?) {
         try {
@@ -27,5 +33,14 @@ open class VercraftExtension(objectFactory: ObjectFactory) {
             logger.error(ERROR_RELEASE_TYPE_PARSING)
             throw IllegalArgumentException(ERROR_RELEASE_TYPE_PARSING)
         }
+    }
+
+    fun setSemVerFromProps(prop: Any?) {
+        semVer.set(
+            prop?.toString()
+                ?.let {
+                    if (it.isValidSemVerFormat()) SemVer(it) else throw IllegalArgumentException(ERROR_SEM_VER_PARSING)
+                }
+        )
     }
 }

--- a/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/VercraftPlugin.kt
+++ b/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/VercraftPlugin.kt
@@ -12,6 +12,7 @@ import javax.inject.Inject
 const val DEFAULT_MAIN_BRANCH = "defaultMainBranch"
 const val CHECKOUT_BRANCH = "checkOutBranch"
 const val RELEASE_TYPE = "releaseType"
+const val SEM_VER = "semVer"
 const val REMOTE = "remote"
 
 class VercraftPlugin @Inject constructor(
@@ -21,8 +22,13 @@ class VercraftPlugin @Inject constructor(
         assert(project == project.rootProject) { "Vercraft plugin should be applied to root project" }
 
         val extension = project.extensions.create("vercraft", VercraftExtension::class.java)
+
+        // === getting gradle properties for the configuration of VerCraft
         extension.setReleaseTypeFromProps(
             project.findProperty(RELEASE_TYPE)
+        )
+        extension.setSemVerFromProps(
+            project.findProperty(SEM_VER)
         )
         extension.config.set(
             Config(
@@ -32,6 +38,7 @@ class VercraftPlugin @Inject constructor(
             )
         )
 
+        // === fetching project
         runGitCommand(
             listOf("git", "fetch", "origin", "--prune", "--tags"),
             "Unable to fetch project from the remote.",
@@ -61,5 +68,6 @@ class VercraftPlugin @Inject constructor(
         project.tasks.register("makeRelease", MakeReleaseTask::class.java) {
             it.releaseType.set(extension.releaseType)
             it.config.set(extension.config)
+            it.semVer.set(extension.semVer)
         }
 }


### PR DESCRIPTION
### What's done:
- New gradle property added: `-PsemVer`
- Supported a gradle task which can make a release with an explicit version