### PR TITLE
Version is calculated based on HEAD commit, but not on the latest one

### DIFF
--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
@@ -82,6 +82,7 @@ public class Releases public constructor(private val git: Git, private val confi
                 git.branchList()
                     .setListMode(REMOTE)
                     .call()
+                    // TODO: handle java.util.NoSuchElementException: Collection contains no element matching the predicate
                     .first { it.name.endsWith(branchName) }
             )
         }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
@@ -72,7 +72,7 @@ public class Releases public constructor(private val git: Git, private val confi
                                 "to VerCraft by setting ENV variable \$VERCRAFT_BRANCH. "
                     )
                     throw NullPointerException(
-                        "Current HEAD is detached and CI env variables with the branch name are not set, so" +
+                        "Current HEAD is detached and CI env variables with the branch name are not set, so " +
                                 "not able to determine the original branch name."
                     )
                 }
@@ -90,6 +90,7 @@ public class Releases public constructor(private val git: Git, private val confi
 
     public fun isReleaseBranch(branch: Branch): Boolean = releaseBranches.find { it.branch == branch } != null
 
+    // TODO: latest release should be calculated relatively to the HEAD commit
     public fun getLatestReleaseBranch(): ReleaseBranch? =
         releaseBranches.maxByOrNull { it.version }
 
@@ -112,7 +113,7 @@ public class Releases public constructor(private val git: Git, private val confi
                     "$ERROR_PREFIX ReleaseType PATCH has been selected, so no new release branches " +
                             "will be created as patch releases should be made only in existing release branch."
                 )
-                // FIXME: need to switch to latest release branch and latest commit and set release tag there
+                // TODO: need to switch to latest release branch and latest commit and set release tag there
             } else {
                 createBranch(newVersion)
                 createTag(newVersion)

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
@@ -131,7 +131,7 @@ public class VersionCalculator(
             dateFormat.timeZone = TimeZone.getDefault()
             val formattedDate = dateFormat.format(Date(commit.commitTime * 1000L))
 
-            return SemVer(NO_MAJOR, NO_MINOR, distance + 1)
+            return SemVer(NO_MAJOR, NO_MINOR, distance)
                 .setPrefix("$formattedDate-$branch")
                 .setPostFix(commit.name.substring(0, 5))
         }

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
@@ -15,7 +15,9 @@ public class VersionCalculator(
     private val currentCheckoutBranch: Branch,
 ) {
     private val repo: Repository = git.repository
-    private val headCommit = repo.resolve("HEAD")
+    private val headCommit = RevWalk(repo).use {
+        it.parseCommit(repo.resolve("HEAD"))
+    }
 
     public fun calc(): SemVer =
         when {
@@ -44,10 +46,12 @@ public class VersionCalculator(
     private fun calcVersionInMain(): SemVer {
         val latestRelease = releases.getLatestReleaseBranch()
         // if no releases were made so far, then will calculate version starting from the initial commit
+        // TODO: latest release should be calculated relatively to the HEAD commit
         val baseCommit = latestRelease?.branch
-            ?.findBaseCommitIn(currentCheckoutBranch) ?: currentCheckoutBranch.gitLog.last()
+            ?.intersectionCommitWithBranch(currentCheckoutBranch)
+            ?: currentCheckoutBranch.gitLog.last()
 
-        val distance = currentCheckoutBranch.numberOfCommitsAfter(baseCommit)
+        val distance = currentCheckoutBranch.distanceBetweenCommits(baseCommit, headCommit)
 
         val shortedHashCode = baseCommit.name.substring(0, 5)
 
@@ -134,12 +138,12 @@ public class VersionCalculator(
     }
 
     private fun distanceFromMainBranch(): Int {
-        val baseCommit = currentCheckoutBranch.findBaseCommitIn(releases.mainBranch)
+        val baseCommit = currentCheckoutBranch.intersectionCommitWithBranch(releases.mainBranch)
             ?: throw IllegalStateException(
                 "Can't find common ancestor commits between ${config.defaultMainBranch} " +
                         "and ${currentCheckoutBranch.ref.name} branches. Looks like these branches have no relation " +
                         "and that is inconsistent git state."
             )
-        return currentCheckoutBranch.numberOfCommitsAfter(baseCommit)
+        return currentCheckoutBranch.distanceBetweenCommits(baseCommit, headCommit)
     }
 }

--- a/core/src/test/kotlin/com/akuleshov7/utils/GitTest.kt
+++ b/core/src/test/kotlin/com/akuleshov7/utils/GitTest.kt
@@ -4,10 +4,12 @@ import com.akuleshov7.vercraft.core.DefaultConfig
 import com.akuleshov7.vercraft.core.Releases
 import org.eclipse.jgit.api.Git
 import java.io.File
+import kotlin.test.Ignore
 import kotlin.test.Test
 
 class GitTest {
     @Test
+    @Ignore
     fun smokeTest() {
         Git.open(File("../")).use { git ->
             val releases = Releases(git, DefaultConfig)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 group=com.akuleshov7.vercraft
-version=0.2.0
+version=0.3.0


### PR DESCRIPTION
### What's done:
- Due to a bug Vercraft has calculated the version based on the latest commit on the branch, even when the checked-out commit was different