### PR TITLE
Adding new safety check for 'makeRelease' task

### DIFF
--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Runner.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Runner.kt
@@ -15,7 +15,7 @@ public fun gitVersion(gitPath: File, config: Config): String {
     }
 }
 
-public fun createRelease(gitPath: File, semVerReleaseType: SemVerReleaseType, config: Config): String {
+public fun makeRelease(gitPath: File, semVerReleaseType: SemVerReleaseType, config: Config): String {
     Git.open(gitPath).use { git ->
         val version = Releases(git, config).createNewRelease(semVerReleaseType)
         logger.warn(">> VerCrafted new release [$version]")
@@ -23,7 +23,7 @@ public fun createRelease(gitPath: File, semVerReleaseType: SemVerReleaseType, co
     }
 }
 
-public fun createRelease(gitPath: File, version: SemVer, config: Config): String {
+public fun makeRelease(gitPath: File, version: SemVer, config: Config): String {
     Git.open(gitPath).use { git ->
         Releases(git, config).createNewRelease(version)
         logger.warn(">> VerCrafted new release [$version]")
@@ -34,4 +34,5 @@ public fun createRelease(gitPath: File, version: SemVer, config: Config): String
 
 public fun main() {
     gitVersion(File("."), Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote))
+    makeRelease(File("."), SemVerReleaseType.MINOR, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote))
 }

--- a/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/MakeReleaseTask.kt
+++ b/plugin-gradle/src/main/kotlin/com/akuleshov7/vercraft/MakeReleaseTask.kt
@@ -31,13 +31,13 @@ abstract class MakeReleaseTask : GitUtilsTask() {
         val semVerVal = semVer.orNull
 
         val version = if (semVerVal != null) {
-            com.akuleshov7.vercraft.core.createRelease(
+            com.akuleshov7.vercraft.core.makeRelease(
                 project.projectDir,
                 semVerVal,
                 DefaultConfig
             )
         } else {
-            com.akuleshov7.vercraft.core.createRelease(
+            com.akuleshov7.vercraft.core.makeRelease(
                 project.projectDir,
                 releaseType.getOrElse(SemVerReleaseType.MINOR),
                 DefaultConfig


### PR DESCRIPTION
### What's done:
- MakeRelease task will not be executed if current checked-out commit is already associated with other release branches