### PR TITLE
Adding the support "X" in patch versions instead of 0

### DIFF
--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/Releases.kt
@@ -213,12 +213,13 @@ public class Releases public constructor(private val git: Git, private val confi
     }
 
     private fun createBranch(newVersion: SemVer) {
+        // new branch is always created with "x" as patch version
         git.branchCreate()
-            .setName("release/$newVersion")
+            .setName("release/${newVersion.semVerForNewBranch()}")
             .call()
             .also { releaseBranches.add(ReleaseBranch(git, config, it, defaultMainBranch)) }
 
-        logger.warn("+ Created a branch [release/$newVersion]")
+        logger.warn("+ Created a branch [release/${newVersion.semVerForNewBranch()}]")
     }
 
     /**

--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/SemVer.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/SemVer.kt
@@ -44,7 +44,10 @@ public class SemVer : Comparable<SemVer> {
         require(ver != null) {
             throw IllegalArgumentException("Can't calculate SemVer version, as received 'null' input")
         }
-        val parts = ver.removeReleasePrefix().split(".").map { it.toInt() }
+        val parts = ver.removeReleasePrefix().split(".").map {
+            // support for both 0.1.x and 0.1.0 versions
+            if (it == "x") 0 else it.toInt()
+        }
         require(parts.size == 3) {
             throw IllegalArgumentException("SemVer version [$this] must be in the following format: 'major.minor.patch'")
         }
@@ -96,6 +99,8 @@ public class SemVer : Comparable<SemVer> {
                 "$major$minor${this.patch}" +
                 (if (postfix != "") "-$postfix" else "")
     }
+
+    public fun semVerForNewBranch(): String = "$major.$minor.${if (patch == 0) "x" else patch}"
 
     public fun justSemVer(): String = "$major.$minor.$patch"
 

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/tests/LatestBranchTest.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/tests/LatestBranchTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 const val DETACHED_COMMIT_RIGHT_AFTER_RELEASE_IN_THE_MIDDLE = "df22d05e681404c1ed98b0db0bf041d60236d14c"
-const val DETACHED_COMMIT_AT_1_1_0 = "9f4c9ba873ed8329a8b913df9bf31c7d81671d8b"
+const val DETACHED_COMMIT_AT_1_1_0 = "9e2e23d82db76a5b6f1aee8a2bb8ffaf485ee9a0"
 const val DETACHED_COMMIT_WITHOUT_RELEASE_BEFORE_IT = "84f4bf70c9ca4da3f6e253d5c206159838ab2522"
 
 class LatestBranchTest {

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/tests/LatestBranchTest.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/tests/LatestBranchTest.kt
@@ -5,10 +5,10 @@ import com.akuleshov7.vercraft.core.Config
 import com.akuleshov7.vercraft.core.DefaultConfig
 import com.akuleshov7.vercraft.core.Releases
 import com.akuleshov7.vercraft.utils.checkoutRef
+import com.akuleshov7.vercraft.utils.vercraftTest
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.revwalk.RevWalk
-import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -19,7 +19,7 @@ const val DETACHED_COMMIT_WITHOUT_RELEASE_BEFORE_IT = "84f4bf70c9ca4da3f6e253d5c
 class LatestBranchTest {
     @Test
     fun `trying to find latest branch for a git log`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, DETACHED_COMMIT_RIGHT_AFTER_RELEASE_IN_THE_MIDDLE)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val commit = RevWalk(releases.repo).use {
@@ -33,7 +33,7 @@ class LatestBranchTest {
 
     @Test
     fun `trying to find latest branch for a git log while we are at release commit`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, DETACHED_COMMIT_AT_1_1_0)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val commit = RevWalk(releases.repo).use {
@@ -47,7 +47,7 @@ class LatestBranchTest {
 
     @Test
     fun `trying to find latest branch for a commit when there were no release branches`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, DETACHED_COMMIT_WITHOUT_RELEASE_BEFORE_IT)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val commit = RevWalk(releases.repo).use {

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/GitMakeNewRelease.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/GitMakeNewRelease.kt
@@ -1,0 +1,44 @@
+package com.akuleshov7.vercraft.tests.functional
+
+import com.akuleshov7.vercraft.core.*
+import com.akuleshov7.vercraft.utils.checkoutRef
+import com.akuleshov7.vercraft.utils.vercraftTest
+import org.eclipse.jgit.api.Git
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class GitMakeNewRelease {
+    @Test
+    fun `make new release`() {
+        deleteBranchAndTag("refs/heads/release/1.2.x", "v1.2.0")
+
+        Git.open(vercraftTest).use { git ->
+            checkoutRef(git, DETACHED_COMMIT_MAIN_AFTER_1_1_X_RELEASE)
+        }
+
+        makeRelease(
+            vercraftTest,
+            SemVerReleaseType.MINOR,
+            Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main"))
+        )
+
+        Git.open(vercraftTest).use { git ->
+            assertNotNull(git.branchList().call().map { it.name }.find { it == "refs/heads/release/1.2.x" })
+        }
+
+        deleteBranchAndTag("refs/heads/release/1.2.x", "v1.2.0")
+    }
+
+    fun deleteBranchAndTag(branch: String, tag: String) {
+        Git.open(vercraftTest).use { git ->
+            git.branchDelete()
+                .setBranchNames(branch)
+                .setForce(true)
+                .call()
+
+            git.tagDelete()
+                .setTags(tag)
+                .call();
+        }
+    }
+}

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/GitTestMainBranch.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/GitTestMainBranch.kt
@@ -5,13 +5,13 @@ import com.akuleshov7.vercraft.core.Config
 import com.akuleshov7.vercraft.core.DefaultConfig
 import com.akuleshov7.vercraft.core.Releases
 import com.akuleshov7.vercraft.utils.checkoutRef
+import com.akuleshov7.vercraft.utils.vercraftTest
 import org.eclipse.jgit.api.Git
-import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 const val DETACHED_COMMIT_RIGHT_AFTER_RELEASE = "4b3a62cf1e783523d3de57691ef5bc4ac11d5c3c"
-const val DETACHED_COMMIT_1_AFTER_RELEASE_MAIN = "9f4c9ba873ed8329a8b913df9bf31c7d81671d8b"
+const val DETACHED_COMMIT_MAIN_AFTER_1_1_X_RELEASE = "a49d7d4e67835e73eb9f049fc8fd46bd03bce714"
 const val DETACHED_COMMIT_BETWEEN_RELEASES = "df22d05e681404c1ed98b0db0bf041d60236d14c"
 const val DETACHED_COMMIT_WITHOUT_RELEASES = "84f4bf70c9ca4da3f6e253d5c206159838ab2522"
 
@@ -19,7 +19,7 @@ const val DETACHED_COMMIT_WITHOUT_RELEASES = "84f4bf70c9ca4da3f6e253d5c206159838
 class GitTestMainBranch {
     @Test
     fun `detached commit from main right after the release but not the last in main`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, DETACHED_COMMIT_RIGHT_AFTER_RELEASE)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val resultedVer = releases.version.calc()
@@ -30,29 +30,29 @@ class GitTestMainBranch {
 
     @Test
     fun `detached commit last in main`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
-            checkoutRef(git, DETACHED_COMMIT_1_AFTER_RELEASE_MAIN)
+        Git.open(vercraftTest).use { git ->
+            checkoutRef(git, DETACHED_COMMIT_MAIN_AFTER_1_1_X_RELEASE)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val resultedVer = releases.version.calc()
             println(resultedVer)
-            assertEquals("1.2.2-main+9f4c9", resultedVer.toString())
+            assertEquals("1.2.2-main+a49d7", resultedVer.toString())
         }
     }
 
     @Test
     fun `just main was checked-out`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, "main")
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val resultedVer = releases.version.calc()
             println(resultedVer)
-            assertEquals("1.2.2-main+9f4c9", resultedVer.toString())
+            assertEquals("1.2.2-main+a49d7", resultedVer.toString())
         }
     }
 
     @Test
     fun `release 1 1 0 commit but on main`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, RELEASE_1_1_0_COMMIT_MAIN)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val resultedVer = releases.version.calc()
@@ -63,7 +63,7 @@ class GitTestMainBranch {
 
     @Test
     fun `commit between releases`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, DETACHED_COMMIT_BETWEEN_RELEASES)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val resultedVer = releases.version.calc()
@@ -74,7 +74,7 @@ class GitTestMainBranch {
 
     @Test
     fun `commit in main before any releases`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, DETACHED_COMMIT_WITHOUT_RELEASES)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("main")))
             val resultedVer = releases.version.calc()

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/GitTestRandomBranch.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/GitTestRandomBranch.kt
@@ -5,8 +5,8 @@ import com.akuleshov7.vercraft.core.Config
 import com.akuleshov7.vercraft.core.DefaultConfig
 import com.akuleshov7.vercraft.core.Releases
 import com.akuleshov7.vercraft.utils.checkoutRef
+import com.akuleshov7.vercraft.utils.vercraftTest
 import org.eclipse.jgit.api.Git
-import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -19,7 +19,7 @@ const val LAST_COMMIT_TEST_BRANCH = "70982520bb947ab4331d3bf25dd73074cad7e8a5"
 class GitTestRandomBranch {
     @Test
     fun `initial commit test branch`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, INITIAL_COMMIT_TEST_BRANCH)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("feature/test")))
             val resultedVer = releases.version.calc()
@@ -30,7 +30,7 @@ class GitTestRandomBranch {
 
     @Test
     fun `first commit test branch`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, FIRST_COMMIT_TEST_BRANCH)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("feature/test")))
             val resultedVer = releases.version.calc()
@@ -41,7 +41,7 @@ class GitTestRandomBranch {
 
     @Test
     fun `second commit test branch`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, SECOND_COMMIT_TEST_BRANCH)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("feature/test")))
             val resultedVer = releases.version.calc()
@@ -52,7 +52,7 @@ class GitTestRandomBranch {
 
     @Test
     fun `last commit test branch`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, LAST_COMMIT_TEST_BRANCH)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("feature/test")))
             val resultedVer = releases.version.calc()
@@ -63,7 +63,7 @@ class GitTestRandomBranch {
 
     @Test
     fun `just test branch`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             if (git.repository.findRef("feature/test") == null) {
                 git.checkout()
                     .setCreateBranch(true)

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/GitTestRelease110Branch.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/GitTestRelease110Branch.kt
@@ -5,8 +5,8 @@ import com.akuleshov7.vercraft.core.Config
 import com.akuleshov7.vercraft.core.DefaultConfig
 import com.akuleshov7.vercraft.core.Releases
 import com.akuleshov7.vercraft.utils.checkoutRef
+import com.akuleshov7.vercraft.utils.vercraftTest
 import org.eclipse.jgit.api.Git
-import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -17,7 +17,7 @@ const val SECOND_COMMIT_IN_RELEASE_1_1_0 = "1f22b4ced648c6b8b5f36dc2e900ffc7b39a
 class GitTestRelease110Branch {
     @Test
     fun `release 1 1 0 commit but on release branch`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, RELEASE_1_1_0_COMMIT_MAIN)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("release/1.1.0")))
             val resultedVer = releases.version.calc()
@@ -28,7 +28,7 @@ class GitTestRelease110Branch {
 
     @Test
     fun `first commit in release 1 1 0, no local branch`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, FIRST_COMMIT_IN_RELEASE_1_1_0)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("release/1.1.0")))
             val resultedVer = releases.version.calc()
@@ -39,7 +39,7 @@ class GitTestRelease110Branch {
 
     @Test
     fun `first commit in release 1 1 0 with checked-out local`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             if (git.repository.findRef("release/1.1.0") == null) {
                 git.checkout()
                     .setCreateBranch(true)
@@ -71,7 +71,7 @@ class GitTestRelease110Branch {
 
     @Test
     fun `second commit in release 1 1 0`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             checkoutRef(git, SECOND_COMMIT_IN_RELEASE_1_1_0)
             val releases = Releases(git, Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("release/1.1.0")))
             val resultedVer = releases.version.calc()
@@ -82,7 +82,7 @@ class GitTestRelease110Branch {
 
     @Test
     fun `release branch checkout local`() {
-        Git.open(File("src/test/resources/vercraft-test")).use { git ->
+        Git.open(vercraftTest).use { git ->
             if (git.repository.findRef("release/1.1.0") == null) {
                 git.checkout()
                     .setCreateBranch(true)

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/SmokeTest.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/SmokeTest.kt
@@ -1,14 +1,11 @@
 package com.akuleshov7.vercraft.tests.functional
 
-import com.akuleshov7.vercraft.core.CheckoutBranch
 import com.akuleshov7.vercraft.core.Config
 import com.akuleshov7.vercraft.core.DefaultConfig
 import com.akuleshov7.vercraft.core.Releases
-import com.akuleshov7.vercraft.utils.checkoutRef
 import org.eclipse.jgit.api.Git
 import java.io.File
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 // NB: Never run this test without a checked-out branch (detached HEAD) locally. On CI it will work due to env variables
 class SmokeTest {

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/utils/Utils.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/utils/Utils.kt
@@ -1,7 +1,9 @@
 package com.akuleshov7.vercraft.utils
 
 import org.eclipse.jgit.api.Git
+import java.io.File
 
+val vercraftTest = File("src/test/resources/vercraft-test")
 
 fun checkoutRef (git: Git, ref: String) {
     git.checkout().setName(ref).call()


### PR DESCRIPTION
### What's done:
- now versions are calculated with X in patch version, for example: 1.1.x. This will make release branch naming more clear;
- polishing tests.