### PR TITLE
fix(core): use existing patch tags as patch-counter anchor on release…

### DIFF
--- a/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
+++ b/core/src/main/kotlin/com/akuleshov7/vercraft/core/VersionCalculator.kt
@@ -1,6 +1,7 @@
 package com.akuleshov7.vercraft.core
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk
@@ -101,16 +102,62 @@ public class VersionCalculator(
      *
      * This scenario applies to PATCH versions. Commits like **xxx** and **yyy** are typically created to implement
      * patches or additional fixes after the release of version **0.1.0** (commit **bbb**).
+     *
+     * (!) When the release branch has already accumulated `v<major>.<minor>.<patch>` tags, those tags
+     * are treated as the authoritative record of past patch releases and the version is computed as
+     * `latest_tag_patch + commits_since_that_tag`. This avoids miscalculations when the release
+     * branch has been merged back into main (which would otherwise shift the merge-base and break
+     * pure commit counting).
      */
     private fun calcVersionInRelease(): SemVer {
-        val distance = distanceFromDefaultMainBranch()
-        return releases.releaseBranches.find { it.ref == currentCheckoutBranch.ref }
+        val branchVersion = releases.releaseBranches.find { it.ref == currentCheckoutBranch.ref }
             ?.version
-            ?.incrementPatchVersion(distance)
             ?: throw IllegalStateException(
                 "Cannot find branch ${currentCheckoutBranch.ref!!.name} in the list of release branches:" +
                         "${releases.releaseBranches}"
             )
+
+        // Prefer existing patch tags when present: they are an authoritative record of what has
+        // already been released, and using them avoids miscalculations when the release branch has
+        // been merged back into main (which shifts the merge-base and breaks pure commit counting).
+        // Falls back to the legacy distance-from-main behaviour when no matching tags exist yet,
+        // preserving backwards compatibility for projects that have never tagged a patch release.
+        val latestPatchTag = findLatestReachablePatchTag(branchVersion)
+        if (latestPatchTag != null) {
+            val (taggedVersion, taggedCommit) = latestPatchTag
+            val sinceTag = currentCheckoutBranch.distanceBetweenCommits(taggedCommit, headCommit)
+            return SemVer(taggedVersion.major, taggedVersion.minor, taggedVersion.patch + sinceTag)
+        }
+
+        val distance = distanceFromDefaultMainBranch()
+        return branchVersion.incrementPatchVersion(distance)
+    }
+
+    /**
+     * Find the highest-patch tag matching the current release branch (`v<major>.<minor>.<patch>`)
+     * that is reachable from the current HEAD commit on this release branch.
+     *
+     * Both annotated and lightweight tags are supported. Tags pointing at commits which are not
+     * part of the release branch history are ignored.
+     */
+    private fun findLatestReachablePatchTag(branchVersion: SemVer): Pair<SemVer, RevCommit>? {
+        val tagPattern = Regex("^v?${branchVersion.major}\\.${branchVersion.minor}\\.(0|[1-9]\\d*)$")
+        val branchCommits: Set<String> = currentCheckoutBranch.gitLog.map { it.id.name }.toSet()
+
+        return git.tagList().call().mapNotNull { tagRef ->
+            val shortName = tagRef.name.substringAfterLast("refs/tags/")
+            val match = tagPattern.matchEntire(shortName) ?: return@mapNotNull null
+            val patch = match.groupValues[1].toInt()
+            val taggedCommit = resolveTaggedCommit(tagRef) ?: return@mapNotNull null
+            if (taggedCommit.id.name !in branchCommits) return@mapNotNull null
+            SemVer(branchVersion.major, branchVersion.minor, patch) to taggedCommit
+        }.maxByOrNull { it.first.patch }
+    }
+
+    private fun resolveTaggedCommit(tagRef: Ref): RevCommit? {
+        val peeled = repo.refDatabase.peel(tagRef)
+        val objectId = peeled.peeledObjectId ?: tagRef.objectId ?: return null
+        return RevWalk(repo).use { walk -> walk.parseCommit(objectId) }
     }
 
     /**

--- a/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/BackMergeReleaseTest.kt
+++ b/core/src/test/kotlin/com/akuleshov7/vercraft/tests/functional/BackMergeReleaseTest.kt
@@ -1,0 +1,119 @@
+package com.akuleshov7.vercraft.tests.functional
+
+import com.akuleshov7.vercraft.core.CheckoutBranch
+import com.akuleshov7.vercraft.core.Config
+import com.akuleshov7.vercraft.core.DefaultConfig
+import com.akuleshov7.vercraft.core.Releases
+import org.eclipse.jgit.api.Git
+import java.io.File
+import java.nio.file.Files
+import kotlin.io.path.createDirectories
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression tests for the scenario where a release branch is merged back into the main branch.
+ *
+ * When the merge happens, every commit on the release branch becomes reachable from main, which
+ * shifts the merge-base forward. A pure commit-distance-from-main calculation will then report a
+ * patch number that has already been released, blocking subsequent publish steps.
+ *
+ * These tests pin the expected behaviour: existing `v<major>.<minor>.<patch>` tags act as the
+ * authoritative anchor for the patch counter, regardless of where the merge-base ends up.
+ */
+class BackMergeReleaseTest {
+
+    @Test
+    fun `release branch merged back into main computes next patch from latest tag`() {
+        withTempGitRepo { git ->
+            // master: M0 (init)
+            commit(git, "init")
+            tag(git, "anchor")
+
+            // create release/0.2.x from master
+            git.branchCreate().setName("release/0.2.x").call()
+            git.checkout().setName("release/0.2.x").call()
+
+            // first patch commit on release branch, tagged v0.2.1
+            commit(git, "fix on release branch")
+            tag(git, "v0.2.1")
+
+            val firstPatchCommit = git.repository.resolve("HEAD").name
+
+            // back-merge release/0.2.x into master
+            git.checkout().setName("main").call()
+            git.merge()
+                .include(git.repository.resolve("release/0.2.x"))
+                .setMessage("Merge release/0.2.x")
+                .call()
+
+            // additional fix on release branch after the back-merge
+            git.checkout().setName("release/0.2.x").call()
+            commit(git, "another fix on release branch")
+
+            val releases = Releases(
+                git,
+                Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("release/0.2.x"))
+            )
+            val resultedVer = releases.version.calc()
+
+            // Expected: v0.2.1 already exists at firstPatchCommit, HEAD is 1 commit ahead → 0.2.2
+            assertEquals("0.2.2", resultedVer.toString())
+
+            // Sanity: the tag really sits on the first patch commit on the release branch
+            val taggedObj = git.repository.refDatabase
+                .peel(git.repository.findRef("refs/tags/v0.2.1"))
+                .let { it.peeledObjectId ?: it.objectId }
+            assertEquals(firstPatchCommit, taggedObj.name)
+        }
+    }
+
+    @Test
+    fun `release branch without any patch tags falls back to commit-distance calculation`() {
+        withTempGitRepo { git ->
+            // master: M0 (init)
+            commit(git, "init")
+
+            // create release/0.3.x from master (no tags yet)
+            git.branchCreate().setName("release/0.3.x").call()
+            git.checkout().setName("release/0.3.x").call()
+            commit(git, "first patch on release branch")
+
+            val releases = Releases(
+                git,
+                Config(DefaultConfig.defaultMainBranch, DefaultConfig.remote, CheckoutBranch("release/0.3.x"))
+            )
+            val resultedVer = releases.version.calc()
+
+            // No tags → legacy behaviour: branch SemVer 0.3.0 + distance(1) = 0.3.1
+            assertEquals("0.3.1", resultedVer.toString())
+        }
+    }
+
+    private fun withTempGitRepo(block: (Git) -> Unit) {
+        val dir = Files.createTempDirectory("vercraft-backmerge-").also { it.createDirectories() }.toFile()
+        try {
+            Git.init().setDirectory(dir).setInitialBranch("main").call().use { git ->
+                git.repository.config.apply {
+                    setString("user", null, "name", "vercraft-test")
+                    setString("user", null, "email", "vercraft-test@example.com")
+                    save()
+                }
+                block(git)
+            }
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    private fun commit(git: Git, message: String) {
+        val marker = File(git.repository.workTree, "marker-${System.nanoTime()}.txt")
+        marker.writeText(message)
+        git.add().addFilepattern(marker.name).call()
+        git.commit().setMessage(message).setSign(false).call()
+    }
+
+    private fun tag(git: Git, name: String) {
+        git.tag().setName(name).setMessage(name).call()
+    }
+}


### PR DESCRIPTION
… branches

Previously `calcVersionInRelease` derived the patch number purely from the commit distance between the release branch and the default main branch. That approach breaks the moment a release branch is merged back into main: the merge brings every release-branch commit into main's history, shifting the merge-base forward and silently lowering the computed patch number to a value that has already been released. The next `makeRelease` / publish attempt then tries to re-create an existing tag and fails.

This change uses `v<major>.<minor>.<patch>` tags reachable from HEAD as the authoritative anchor when they exist: the patch number becomes `latest_tag_patch + commits_since_that_tag`. Both annotated and lightweight tags are honoured; tags that do not sit on the release branch's history are ignored. When no matching tags exist yet the calculation falls back to the original distance-from-main behaviour, so existing projects that have never tagged a patch release see no change.

Closes: #86 